### PR TITLE
Optimize point cloud converter script

### DIFF
--- a/src/utils/point_cloud_converter.py
+++ b/src/utils/point_cloud_converter.py
@@ -31,17 +31,21 @@ def convert_input_pc_to_open3d_pc(pc):
 
 def convert_pc_to_open3d_pc(pc):
     o3d_pc = o3d.geometry.PointCloud()
-
     # Convert coordinates
     vertices = pc["vertex"]
     points = np.stack((np.asarray(pc.elements[0]["x"]),
                        np.asarray(pc.elements[0]["y"]),
-                       np.asarray(pc.elements[0]["z"])), axis=1)
-    o3d_pc.points.extend(points)
+                       np.asarray(pc.elements[0]["z"])), axis=1,dtype=np.float64)
+    o3d_pc.points = o3d.utility.Vector3dVector(points)
 
     # Convert color data
-    colors = np.vstack([vertices['f_dc_0'], vertices['f_dc_1'], vertices['f_dc_2']]).T
-    o3d_pc.colors.extend(colors)
+    colors = np.vstack([np.asarray(vertices['f_dc_0']), 
+                        np.asarray(vertices['f_dc_1']), 
+                        np.asarray(vertices['f_dc_2'])],dtype=np.float64).T
+    
+    # Convert color data to C-contiguous array for speedup
+    colors = np.ascontiguousarray(colors)
+    o3d_pc.colors = o3d.utility.Vector3dVector(colors)
 
     scale_names = [p.name for p in vertices.properties if p.name.startswith("scale_")]
     scale_names = sorted(scale_names, key=lambda x: int(x.split('_')[-1]))
@@ -55,12 +59,10 @@ def convert_pc_to_open3d_pc(pc):
     for idx, attr_name in enumerate(rot_names):
         quaternions[:, idx] = np.asarray(pc.elements[0][attr_name])
 
-    covariance_matrices = convert_to_covariance_matrix(scaling, quaternions)
-    o3d_pc.covariances.extend(covariance_matrices)
+    covariance_matrices = convert_to_covariance_matrix(scaling, quaternions).astype(np.float64)
+    o3d_pc.covariances = o3d.utility.Matrix3dVector(covariance_matrices)
 
-    # get the normals from the covariance matrices
     normal_matrices = get_normals_from_covariance(np.asarray(o3d_pc.covariances))
-    o3d_pc.normals.extend(normal_matrices)
-
+    o3d_pc.normals = o3d.utility.Vector3dVector(normal_matrices)
     o3d_pc.orient_normals_consistent_tangent_plane(30)
     return o3d_pc


### PR DESCRIPTION
optimized the process of converting 3D GS (Gaussian Splatting) to Open3D point cloud from dozens of minutes to around 200 seconds.